### PR TITLE
Stateful JWTs: Addressing issue #2

### DIFF
--- a/backend/BookxBackend/Authorization/AccessOwnedLibraryAuthorizationHandler.cs
+++ b/backend/BookxBackend/Authorization/AccessOwnedLibraryAuthorizationHandler.cs
@@ -1,0 +1,57 @@
+using Bookx.Models;
+using Bookx.Services;
+using Microsoft.AspNetCore.Authorization;
+using System.IdentityModel.Tokens.Jwt;
+
+namespace Bookx.Authorization;
+
+public class AccessOwnedLibraryAuthorizationHandler : AuthorizationHandler<AccessOwnedLibraryRequirement>
+{
+    private readonly ILogger<UserRelatedService> _logger;
+    private readonly BookxContext _bookxContext;
+
+
+    public AccessOwnedLibraryAuthorizationHandler(
+            ILogger<UserRelatedService> logger,
+            BookxContext bookxContext)
+    {
+        _logger = logger;
+        _bookxContext = bookxContext;
+    }
+
+    protected override async Task HandleRequirementAsync(AuthorizationHandlerContext context, AccessOwnedLibraryRequirement requirement)
+    {
+        var userIdClaim = context.User.FindFirst(JwtRegisteredClaimNames.Sub);
+        var userJwtVersionClaim = context.User.FindFirst(JwtRegisteredClaimNames.Jti);
+
+        int userId;
+        var validUserId = Int32.TryParse(userIdClaim?.Value, out userId);
+
+        int userJwtVersion;
+        var validUserJwtVersion = Int32.TryParse(userJwtVersionClaim?.Value, out userJwtVersion);
+
+        if (userIdClaim == null || !validUserId || userJwtVersionClaim == null || !validUserJwtVersion)
+        {
+            context.Fail();
+            return;
+        }
+
+        var authenticatedUser = await _bookxContext.Users.FindAsync(userId);
+
+        Console.WriteLine("In here");
+
+        if (authenticatedUser.JwtVersion <= userJwtVersion)
+        {
+
+            Console.WriteLine(authenticatedUser.JwtVersion);
+            Console.WriteLine(userJwtVersion);
+
+            context.Succeed(requirement);
+        }
+        else
+        {
+            context.Fail();
+        }
+
+    }
+}

--- a/backend/BookxBackend/Authorization/AccessOwnedLibraryAuthorizationHandler.cs
+++ b/backend/BookxBackend/Authorization/AccessOwnedLibraryAuthorizationHandler.cs
@@ -38,20 +38,13 @@ public class AccessOwnedLibraryAuthorizationHandler : AuthorizationHandler<Acces
 
         var authenticatedUser = await _bookxContext.Users.FindAsync(userId);
 
-        Console.WriteLine("In here");
-
         if (authenticatedUser.JwtVersion <= userJwtVersion)
         {
-
-            Console.WriteLine(authenticatedUser.JwtVersion);
-            Console.WriteLine(userJwtVersion);
-
             context.Succeed(requirement);
         }
         else
         {
             context.Fail();
         }
-
     }
 }

--- a/backend/BookxBackend/Authorization/AccessOwnedLibraryRequirement.cs
+++ b/backend/BookxBackend/Authorization/AccessOwnedLibraryRequirement.cs
@@ -1,0 +1,7 @@
+using Microsoft.AspNetCore.Authorization;
+
+namespace Bookx.Authorization;
+
+public class AccessOwnedLibraryRequirement : IAuthorizationRequirement
+{
+}

--- a/backend/BookxBackend/Helpers/CryptographyHelper.cs
+++ b/backend/BookxBackend/Helpers/CryptographyHelper.cs
@@ -60,12 +60,13 @@ public static class CryptographyHelper
         return areHashesEqual;
     }
 
-    public static string GenerateJwt(int userId, string userMailAddress)
+    public static string GenerateJwt(int userId, string username, int newJwtVersion)
     {
         var claims = new[]
         {
             new Claim(JwtRegisteredClaimNames.Sub, userId.ToString()),
-            new Claim(JwtRegisteredClaimNames.Email, userMailAddress)
+            new Claim(JwtRegisteredClaimNames.Name, userId.ToString()),
+            new Claim(JwtRegisteredClaimNames.Jti, newJwtVersion.ToString())
         };
 
         var credentials = new SigningCredentials(JwtSecurityKey, _jwtSecurityAlgorithm);

--- a/backend/BookxBackend/Migrations/20250609183648_JwtVersioning.Designer.cs
+++ b/backend/BookxBackend/Migrations/20250609183648_JwtVersioning.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Bookx.Models;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace BookxBackend.Migrations
 {
     [DbContext(typeof(BookxContext))]
-    partial class BookxContextModelSnapshot : ModelSnapshot
+    [Migration("20250609183648_JwtVersioning")]
+    partial class JwtVersioning
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/BookxBackend/Migrations/20250609183648_JwtVersioning.cs
+++ b/backend/BookxBackend/Migrations/20250609183648_JwtVersioning.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace BookxBackend.Migrations
+{
+    /// <inheritdoc />
+    public partial class JwtVersioning : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "JwtVersion",
+                table: "Users",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "JwtVersion",
+                table: "Users");
+        }
+    }
+}

--- a/backend/BookxBackend/Models/UserRelated.cs
+++ b/backend/BookxBackend/Models/UserRelated.cs
@@ -8,6 +8,7 @@ namespace Bookx.Models
         public string PasswordSalt { get; set; }
         public DateTime JoinDatetime { get; set; }
         public string MailAddress { get; set; }
+        public int JwtVersion { get; set; }
         public ICollection<Tag> Tags { get; } = new List<Tag>();
         public ICollection<Book> Books { get; } = new List<Book>();
         public ICollection<OwnedBook> OwnedBooks { get; set; } = new List<OwnedBook>();

--- a/backend/BookxBackend/Program.cs
+++ b/backend/BookxBackend/Program.cs
@@ -1,7 +1,9 @@
+using Bookx.Authorization;
 using Bookx.Services;
 using Bookx.Models;
 using Bookx.Helpers;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.IdentityModel.Tokens;
 using Microsoft.EntityFrameworkCore;
 using System.IdentityModel.Tokens.Jwt;
@@ -39,7 +41,14 @@ builder.Services.AddCors(o => o.AddPolicy("AllowAll", builder =>
             .WithExposedHeaders("Grpc-Status", "Grpc-Message", "Grpc-Encoding", "Grpc-Accept-Encoding");
 }));
 
-builder.Services.AddAuthorization();
+builder.Services.AddScoped<IAuthorizationHandler, AccessOwnedLibraryAuthorizationHandler>();
+
+builder.Services.AddAuthorization(options =>
+{
+    options.AddPolicy("ValidJwt", policy =>
+        policy.Requirements.Add(new AccessOwnedLibraryRequirement())
+    );
+});
 
 var app = builder.Build();
 

--- a/backend/BookxBackend/Services/UserRelatedService.cs
+++ b/backend/BookxBackend/Services/UserRelatedService.cs
@@ -10,7 +10,7 @@ using System.Text.RegularExpressions;
 
 namespace Bookx.Services;
 
-[Authorize]
+[Authorize(Policy = "ValidJwt")]
 public class UserRelatedService : UserService.UserServiceBase
 {
     #region Fields
@@ -444,6 +444,7 @@ public class UserRelatedService : UserService.UserServiceBase
     private int? GetUserIdFromClaim(ServerCallContext context)
     {
         var userIdClaim = context.GetHttpContext().User.FindFirst(JwtRegisteredClaimNames.Sub);
+        var userJwtVersion = context.GetHttpContext().User.FindFirst(JwtRegisteredClaimNames.Jti);
 
         int userId;
         var validUserId = Int32.TryParse(userIdClaim?.Value, out userId);


### PR DESCRIPTION
The motivation has already been explained in issue #2. I'm making JWTs stateful by adding a version claim and storing the most recent one alongside the user in the database. This allows the backend to check if a token is invalid and can't be used for authentication. The new flow looks like this:

1. User logs in by entering username and password as before
2. If the credentials are valid, the stored JWT version of the user increases by 1, the generated JWT contains the following claims
    - sub: user ID
    - name: username
    - JTI: JWT version at that time
3. Only the latest JWT can be used for further authentication and authorization, requests with older JWTs are denied
4. Once the JWT expires or the user logs in again, the JWT version increases by 1 again and a new JWT is generated